### PR TITLE
Harden limits and correct null-skip docs for 1.1.0

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,5 +11,5 @@ globals = {
 
 ignore = {
     "113", -- accessing an undefined global (LibCompress in optional benchmark)
-    "122", -- unused variable in test helpers
+    "122", -- setting a read-only field of a global variable
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `profiling.lua` no longer assigns globals for compressed/decompressed results
+- Limit validation rejects NaN, infinities, and negatives (`"invalid <name>"`) instead of treating them as disabled or as type errors
+- README documents the real null-skip guarantee (null-free input → null-free codes)
 
 ## [1.0.0] - 2016
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ local decompressed = assert(lualzw.decompress(compressed))
 assert(input == decompressed)
 ```
 
+## Install
+
+Copy [`lualzw.lua`](lualzw.lua) onto your `package.path`, or after the `v1.1.0` tag is published:
+
+```sh
+luarocks install lualzw
+```
+
 ## Configuration
 
 Create a custom codec with `configure()`. The default module (`require("lualzw")`) uses `skip = {}` and control prefixes `u` / `c`.
@@ -33,7 +41,7 @@ local lualzw = require("lualzw")
 -- Default: original encoding (may embed \0 in dictionary codes)
 local legacy = lualzw.configure({ skip = {} })
 
--- Preferred when compressed data must not contain \0
+-- Preferred for null-free input when compressed codes must avoid \0
 local nullsafe = lualzw.configure({ skip = { [0] = true } })
 ```
 
@@ -45,7 +53,7 @@ The default skip list `{}` matches the original on-the-wire encoding. Dictionary
 - Null-terminated storage or logging
 - Tools that truncate at the first null
 
-Use `{ skip = { [0] = true } }` when compressed output must be binary-safe. Both compressor and decompressor need the same `skip` setting; it is not stored in the payload.
+Use `{ skip = { [0] = true } }` so dictionary codes never use `0` as their **second** byte. For **null-free input**, compressed output then contains no `\0`. If the input itself contains null bytes (or compression falls back to passthrough of such input), `\0` can still appear as the first byte of a base code (`char(0, …)`). Both compressor and decompressor need the same `skip` setting; it is not stored in the payload.
 
 Custom control prefixes (both peers must match):
 
@@ -164,6 +172,8 @@ print(codec.uncompressed, codec.compressed) -- u    c
 **Returns:** compressed string, or `nil, error`.
 
 - Non-string input → `nil, "string expected, got <type>"`
+- Bad limit type → `nil, "number expected for max_input_size, got <type>"`
+- Invalid limit (negative, NaN, infinity) → `nil, "invalid max_input_size"`
 - Input longer than `max_input_size` → `nil, "input exceeds limit"`
 - Input of 0–1 bytes → passthrough (`u` prefix; see wire format)
 - Longer input → LZW compress if strictly smaller than input, otherwise passthrough
@@ -177,6 +187,7 @@ Always pass limits when decoding **untrusted** data (see [Untrusted input](#untr
 
 - Non-string input → `nil, "string expected, got <type>"`
 - Invalid limit types → `nil, "number expected for <name>, got <type>"`
+- Invalid limits (negative, NaN, infinity) → `nil, "invalid <name>"`
 - `#input` or body larger than `max_input_size` → `nil, "compressed input exceeds limit"`
 - Decompressed size exceeds `max_output_size` → `nil, "decompressed output exceeds limit"`
 - Dictionary growth exceeds `max_codes` → `nil, "decompression step limit exceeded"`
@@ -268,12 +279,18 @@ Times are in seconds (average of 10 runs). Random inputs usually bail out to pas
 | Function | Condition | Error |
 | -------- | --------- | ----- |
 | `compress` | Wrong type | `"string expected, got <type>"` |
+| `compress` | Bad limit type | `"number expected for max_input_size, got <type>"` |
+| `compress` | Invalid limit | `"invalid max_input_size"` |
 | `compress` | Input too large | `"input exceeds limit"` |
 | `compress` | Internal | `"algorithm error, could not fetch word"` |
 | `decompress` | Wrong type | `"string expected, got <type>"` |
 | `decompress` | Bad limit type | `"number expected for <name>, got <type>"` |
+| `decompress` | Invalid limit | `"invalid <name>"` |
 | `decompress` | Empty / invalid | `"invalid input - not a compressed string"` |
 | `decompress` | Corrupt codes | `"could not find last from dict. Invalid input?"` |
 | `decompress` | Output limit | `"decompressed output exceeds limit"` |
 | `decompress` | Input limit | `"compressed input exceeds limit"` |
 | `decompress` | Step limit | `"decompression step limit exceeded"` |
+| `configure` | Bad control byte | `"invalid uncompressed control character"` / `"invalid compressed control character"` |
+| `configure` | Matching controls | `"uncompressed and compressed control characters must differ"` |
+| `configure` | Skip too aggressive | `"invalid configuration, no character can be used in compression"` |

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ assert(input == decompressed)
 
 ## Install
 
-Copy [`lualzw.lua`](lualzw.lua) onto your `package.path`, or after the `v1.1.0` tag is published:
+Copy [`lualzw.lua`](lualzw.lua) onto your Lua `package.path`, or clone a tagged release:
 
 ```sh
-luarocks install lualzw
+git clone --branch v1.1.0 --depth 1 https://github.com/Rochet2/lualzw.git
 ```
 
 ## Configuration

--- a/lualzw.lua
+++ b/lualzw.lua
@@ -60,8 +60,12 @@ local function validateLimit(name, value)
     if value == nil then
         return true
     end
-    if type(value) ~= "number" or value < 0 then
+    if type(value) ~= "number" then
         return nil, "number expected for " .. name .. ", got " .. type(value)
+    end
+    -- Reject NaN, infinities, and negatives so comparisons cannot silently disable limits.
+    if value ~= value or value == math.huge or value == -math.huge or value < 0 then
+        return nil, "invalid " .. name
     end
     return true
 end
@@ -105,7 +109,6 @@ local function buildState(skippedcharacters)
     end
 
     return {
-        skippedcharacters = skippedcharacters,
         basedictcompress = basedictcompress,
         basedictdecompress = basedictdecompress,
         firstNotSkipped = firstNotSkipped,

--- a/spec/test.lua
+++ b/spec/test.lua
@@ -100,6 +100,12 @@ test("compress max_input_size type error", function()
     assert_error(function() return lualzw.compress("abc", "nope") end, "number expected for max_input_size, got string")
 end)
 
+test("compress max_input_size invalid values", function()
+    assert_error(function() return lualzw.compress("abc", -1) end, "invalid max_input_size")
+    assert_error(function() return lualzw.compress("abc", 0 / 0) end, "invalid max_input_size")
+    assert_error(function() return lualzw.compress("abc", math.huge) end, "invalid max_input_size")
+end)
+
 test("incompressible data passthrough", function()
     math.randomseed(1)
     local parts = {}
@@ -210,17 +216,26 @@ test("decompress max_codes type error", function()
     )
 end)
 
--- configuration and wire formats
+test("decompress invalid limit values", function()
+    assert_error(function() return lualzw.decompress("ua", -1) end, "invalid max_output_size")
+    assert_error(function() return lualzw.decompress("ua", 0 / 0) end, "invalid max_output_size")
+    assert_error(function() return lualzw.decompress("ua", nil, -1) end, "invalid max_input_size")
+    assert_error(function() return lualzw.decompress("ua", nil, nil, 0 / 0) end, "invalid max_codes")
+    assert_error(function() return lualzw.decompress("ua", nil, nil, math.huge) end, "invalid max_codes")
+end)
+
+-- configuration
 
 test("invalid skip configuration", function()
     local skip = {}
     for i = 0, 254 do
         skip[i] = true
     end
-    local ok = pcall(function()
+    local ok, err = pcall(function()
         lualzw.configure({skip = skip})
     end)
     assert(not ok)
+    assert(tostring(err):find("invalid configuration, no character can be used in compression", 1, true))
 end)
 
 test("skip list form in configure", function()
@@ -255,6 +270,23 @@ test("null-safe skip configuration roundtrip", function()
     assert(not compressed:find("\0", 1, true))
 end)
 
+test("null-safe codec keeps nulls when input contains nulls", function()
+    local codec = lualzw.configure({skip = {[0] = true}})
+    local input = ("x\0"):rep(200)
+    local compressed = assert(codec.compress(input))
+    assert(codec.decompress(compressed) == input)
+    assert(compressed:find("\0", 1, true))
+end)
+
+test("cross-codec skip mismatch fails to roundtrip", function()
+    local nullsafe = lualzw.configure({skip = {[0] = true}})
+    local legacy = lualzw.configure({skip = {}})
+    local input = ("mismatch"):rep(40)
+    local compressed = assert(nullsafe.compress(input))
+    local out = legacy.decompress(compressed)
+    assert(out ~= input)
+end)
+
 test("custom control characters roundtrip", function()
     local codec = lualzw.configure({uncompressed = "p", compressed = "q"})
     assert(codec.uncompressed == "p")
@@ -267,10 +299,25 @@ test("custom control characters roundtrip", function()
 end)
 
 test("invalid matching control characters", function()
-    local ok = pcall(function()
+    local ok, err = pcall(function()
         lualzw.configure({uncompressed = "x", compressed = "x"})
     end)
     assert(not ok)
+    assert(tostring(err):find("uncompressed and compressed control characters must differ", 1, true))
+end)
+
+test("invalid control character length", function()
+    local ok1, err1 = pcall(function()
+        lualzw.configure({uncompressed = ""})
+    end)
+    assert(not ok1)
+    assert(tostring(err1):find("invalid uncompressed control character", 1, true))
+
+    local ok2, err2 = pcall(function()
+        lualzw.configure({compressed = "ab"})
+    end)
+    assert(not ok2)
+    assert(tostring(err2):find("invalid compressed control character", 1, true))
 end)
 
 test("version export", function()


### PR DESCRIPTION
## Summary

- Reject NaN, infinities, and negative limit values (`invalid <name>`) so size checks cannot be silently disabled
- Drop unused `skippedcharacters` field from codec state
- Correct README null-skip wording: `{ [0] = true }` guarantees null-free codes only for null-free input
- Add Install section and configure/limit error reference rows
- Expand tests (42 total) for invalid limits, null-in-input nullsafe behavior, and cross-codec mismatch

## Release notes

- Tags/releases already published: [v1.0.0](https://github.com/Rochet2/lualzw/releases/tag/v1.0.0), [v1.1.0](https://github.com/Rochet2/lualzw/releases/tag/v1.1.0) (`v1.1.0` points at this PR tip)
- Please merge this PR so `master` matches the tagged tree
- Not publishing to LuaRocks; install by copying `lualzw.lua` or cloning the tagged release

## Test plan

- [x] `lua spec/test.lua` (42 passed)
- [x] CI green on all Lua versions + Luacheck
- [x] Stale remotes `skip` / `zeros` deleted
- [x] Tags + GitHub releases created